### PR TITLE
fixup copy'n'paste error in options

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func init() {
 	flag.StringVar(&leader, "leader", "", "SkyDNS Leader")
 	flag.StringVar(&domain, "domain", "skydns.local", "Domain to anchor requests to")
 	flag.StringVar(&ldns, "dns", "127.0.0.1:53", "IP:Port to bind to for DNS")
-	flag.StringVar(&ldns, "http", "127.0.0.1:8080", "IP:Port to bind to for HTTP")
+	flag.StringVar(&lhttp, "http", "127.0.0.1:8080", "IP:Port to bind to for HTTP")
 	flag.StringVar(&dataDir, "data", "./data", "SkyDNS data directory")
 	flag.DurationVar(&rtimeout, "rtimeout", 2*time.Second, "Read timeout")
 	flag.DurationVar(&wtimeout, "wtimeout", 2*time.Second, "Write timeout")


### PR DESCRIPTION
The http option parses into the dns option, leading to a bug in
operating the server.
