### PR TITLE
add metrics support - graphite, stathat, command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Which takes the following flags
 - -data - Directory that Raft logs will be stored in (Defaults to: ./data)
 - -join - When running a cluster of SkyDNS servers as recommended, you'll need to supply followers with where the other members can be found, this can be any member or a comma separated list of members. It does not have to be the leader. Any non-leader you join will redirect you to the leader automatically.
 - -discover - This flag can be used in place of explicitly supplying cluster members via the -join flag. It performs a DNS lookup using the hosts DNS server for NS records associated with the -domain flag to find the SkyDNS instances.
+- -metricsToStdErr - When this flag is set to true, metrics will be periodically written to standard error
+- -graphiteServer - When this flag is set to a Graphite Server URL:PORT, metrics will be posted to a graphite server
+- -stathatUser - When this flag is set to a valid StatHat user, metrics will be posted to that user's StatHat account periodically
 
 ##API
 ### Service Announcements

--- a/main.go
+++ b/main.go
@@ -3,8 +3,11 @@ package main
 import (
 	"flag"
 	"github.com/goraft/raft"
+	"github.com/rcrowley/go-metrics"
+	"github.com/rcrowley/go-metrics/stathat"
 	"log"
 	"net"
+	"os"
 	"strings"
 	"time"
 )
@@ -13,6 +16,8 @@ var (
 	join, ldns, lhttp, dataDir, domain string
 	rtimeout, wtimeout                 time.Duration
 	discover                           bool
+	metricsToStdErr                    bool
+	graphiteServer, stathatUser        string
 )
 
 func init() {
@@ -24,6 +29,9 @@ func init() {
 	flag.StringVar(&dataDir, "data", "./data", "SkyDNS data directory")
 	flag.DurationVar(&rtimeout, "rtimeout", 2*time.Second, "Read timeout")
 	flag.DurationVar(&wtimeout, "wtimeout", 2*time.Second, "Write timeout")
+	flag.BoolVar(&metricsToStdErr, "metricsToStdErr", false, "Write metrics to stderr periodically")
+	flag.StringVar(&graphiteServer, "graphiteServer", "", "Graphite Server connection string e.g. 127.0.0.1:2003")
+	flag.StringVar(&stathatUser, "stathatUser", "", "StatHat account for metrics")
 }
 
 func main() {
@@ -54,6 +62,22 @@ func main() {
 	}
 
 	s := NewServer(members, domain, ldns, lhttp, dataDir, rtimeout, wtimeout)
+
+	// Set up metrics if specified on the command line
+	if metricsToStdErr {
+		go metrics.Log(metrics.DefaultRegistry, 60e9, log.New(os.Stderr, "metrics: ", log.Lmicroseconds))
+	}
+
+	if len(graphiteServer) > 1 {
+		addr, err := net.ResolveTCPAddr("tcp", graphiteServer)
+		if err != nil {
+			go metrics.Graphite(metrics.DefaultRegistry, 10e9, "skydns", addr)
+		}
+	}
+
+	if len(stathatUser) > 1 {
+		go stathat.Stathat(metrics.DefaultRegistry, 10e9, stathatUser)
+	}
 
 	waiter := s.Start()
 	waiter.Wait()


### PR DESCRIPTION
This PR adds go-metrics support, logging to stdError, graphite, and stathat if the command line flags are set appropriately.
