### PR TITLE
Use '*' as a wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ This is where we've changed things up a bit, notice we used the "*" wildcard for
 	;; ANSWER SECTION:
 	east.*.testservice.production.skydns.local. 531  IN SRV	10 50 80   web1.site.com.
 	east.*.testservice.production.skydns.local. 3881 IN SRV	10 50 8080 web2.site.com.
-	east.*n.testservice.production.skydns.local. 3531 IN SRV	20 33 9000 server24.
+	east.*.testservice.production.skydns.local. 3531 IN SRV	20 33 9000 server24.
 	east.*.testservice.production.skydns.local. 3887 IN SRV	20 33 80   web3.site.com.
 	east.*.testservice.production.skydns.local. 3892 IN SRV	20 33 80   web4.site.com.
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ The domain syntax when querying follows a pattern where the right most positions
 - 1-0-0.authservice.production.skydns.local - Is the same as above but restricting it to only version 1.0.0
 - east.1-0-0.authservice.production.skydns.local - Would add the restriction that the services must be running in the East region
 
-In addition to only needing to specify as much of the domain as required for the granularity level you're looking for, you may also supply the wildcard **any** or **all** in any of the positions.
+In addition to only needing to specify as much of the domain as required for the granularity level you're looking for, you may also supply the wildcard `*` in any of the positions.
 
-- east.any.any.production.skydns.local - Would return all services in the East region, that are a part of the production environment.
+- east.*.*.production.skydns.local - Would return all services in the East region, that are a part of the production environment.
 
 ###Examples
 
@@ -152,19 +152,19 @@ Now we can try some of our example DNS lookups:
 	;; MSG SIZE  rcvd: 346
 	
 #####All TestService Instances at any version, within the East region
-`dig @localhost east.any.testservice.production.skydns.local SRV`
+`dig @localhost east.*.testservice.production.skydns.local SRV`
 
-This is where we've changed things up a bit, notice we used the "any" wildcard for version so we get any version, and because we've supplied an explicit region that we're looking for we get that as the highest DNS priority, with the weight being distributed evenly, then all of our West instances still show up for fail-over, but with a higher Priority.
+This is where we've changed things up a bit, notice we used the "*" wildcard for version so we get any version, and because we've supplied an explicit region that we're looking for we get that as the highest DNS priority, with the weight being distributed evenly, then all of our West instances still show up for fail-over, but with a higher Priority.
 
 	;; QUESTION SECTION:
-	;east.any.testservice.production.skydns.local. IN	SRV
+	;east.*.testservice.production.skydns.local. IN	SRV
 
 	;; ANSWER SECTION:
-	east.any.testservice.production.skydns.local. 531  IN SRV	10 50 80   web1.site.com.
-	east.any.testservice.production.skydns.local. 3881 IN SRV	10 50 8080 web2.site.com.
-	east.any.testservice.production.skydns.local. 3531 IN SRV	20 33 9000 server24.
-	east.any.testservice.production.skydns.local. 3887 IN SRV	20 33 80   web3.site.com.
-	east.any.testservice.production.skydns.local. 3892 IN SRV	20 33 80   web4.site.com.
+	east.*.testservice.production.skydns.local. 531  IN SRV	10 50 80   web1.site.com.
+	east.*.testservice.production.skydns.local. 3881 IN SRV	10 50 8080 web2.site.com.
+	east.*n.testservice.production.skydns.local. 3531 IN SRV	20 33 9000 server24.
+	east.*.testservice.production.skydns.local. 3887 IN SRV	20 33 80   web3.site.com.
+	east.*.testservice.production.skydns.local. 3892 IN SRV	20 33 80   web4.site.com.
 
 	;; Query time: 0 msec
 	;; SERVER: 127.0.0.1#53(127.0.0.1)

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -149,7 +149,7 @@ func TestGet(t *testing.T) {
 	}
 
 	// Test Wildcard
-	results, err = reg.Get("any.localhost.test.all.testservice.production")
+	results, err = reg.Get("*.localhost.test.*.testservice.production")
 
 	if err != nil {
 		t.Fatal(err)
@@ -170,8 +170,8 @@ func TestGet(t *testing.T) {
 		t.Fatal("Failed to return correct services")
 	}
 
-	// Test only supplying any for environment
-	results, err = reg.Get("any")
+	// Test only supplying * for environment
+	results, err = reg.Get("*")
 
 	if err != nil {
 		t.Fatal(err)

--- a/server/externalapi.go
+++ b/server/externalapi.go
@@ -19,7 +19,7 @@ func (s *Server) getRegionsHTTPHandler(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	srv, err := s.registry.Get("any")
+	srv, err := s.registry.Get("*")
 	if err != nil {
 		switch err {
 		case registry.ErrNotExists:
@@ -59,7 +59,7 @@ func (s *Server) getEnvironmentsHTTPHandler(w http.ResponseWriter, req *http.Req
 		return
 	}
 
-	srv, err := s.registry.Get("any")
+	srv, err := s.registry.Get("*")
 	if err != nil {
 		switch err {
 		case registry.ErrNotExists:
@@ -104,7 +104,7 @@ func (s *Server) getServicesHTTPHandler(w http.ResponseWriter, req *http.Request
 	var q string
 
 	if q = req.URL.Query().Get("query"); q == "" {
-		q = "any"
+		q = "*"
 	}
 
 	log.Println("Retrieving All Services for query", q)

--- a/server/server.go
+++ b/server/server.go
@@ -439,9 +439,9 @@ func (s *Server) getSRVRecords(q dns.Question) (records []dns.RR, err error) {
 	labels := dns.SplitDomainName(key)
 
 	pos := len(labels) - 4
-	if len(labels) >= 4 && labels[pos] != "any" && labels[pos] != "all" {
+	if len(labels) >= 4 && labels[pos] != "*" {
 		region := labels[pos]
-		labels[pos] = "any"
+		labels[pos] = "*"
 
 		// TODO: This is pretty much a copy of the above, and should be abstracted
 		additionalServices := make([]msg.Service, len(services))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -496,11 +496,11 @@ var dnsTestCases = []dnsTestCase{
 
 	// Region Priority Test
 	{
-		Question: "region1.any.testservice.production.skydns.local.",
+		Question: "region1.*.testservice.production.skydns.local.",
 		Answer: []dns.SRV{
 			{
 				Hdr: dns.RR_Header{
-					Name:   "region1.any.testservice.production.skydns.local.",
+					Name:   "region1.*.testservice.production.skydns.local.",
 					Ttl:    30,
 					Rrtype: dns.TypeSRV,
 				},
@@ -511,7 +511,7 @@ var dnsTestCases = []dnsTestCase{
 			},
 			{
 				Hdr: dns.RR_Header{
-					Name:   "region1.any.testservice.production.skydns.local.",
+					Name:   "region1.*.testservice.production.skydns.local.",
 					Ttl:    33,
 					Rrtype: dns.TypeSRV,
 				},
@@ -522,7 +522,7 @@ var dnsTestCases = []dnsTestCase{
 			},
 			{
 				Hdr: dns.RR_Header{
-					Name:   "region1.any.testservice.production.skydns.local.",
+					Name:   "region1.*.testservice.production.skydns.local.",
 					Ttl:    34,
 					Rrtype: dns.TypeSRV,
 				},
@@ -541,11 +541,11 @@ type servicesTest struct {
 }
 
 var serviceTestArray []servicesTest = []servicesTest{
-	{"any", 7},
+	{"*", 7},
 	{"production", 5},
 	{"testservice.production", 3},
-	{"region1.any.any.production", 1},
-	{"region1.any.testservice.production", 1},
+	{"region1.*.*.production", 1},
+	{"region1.*.testservice.production", 1},
 }
 
 func TestGetServicesWithQueries(t *testing.T) {


### PR DESCRIPTION
In DNS land the '_' is the wildcard, so it seems natural to use this. Removed the use of any and all. The replies from 
SkyDNS could be full hostnames, so you would never see the '_' echoed back. However this last bit isn't implemented.

I know this change is not backward compatible (at least not with this patch).
