### PR TITLE
Add a proper license header to each source file.

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013 Erik St. Martin, Brian Ketelsen. All rights reserved.
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
 package main
 
 import (

--- a/msg/service.go
+++ b/msg/service.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013 Erik St. Martin, Brian Ketelsen. All rights reserved.
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
 package msg
 
 import (

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013 Erik St. Martin, Brian Ketelsen. All rights reserved.
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
 package registry
 
 import (

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013 Erik St. Martin, Brian Ketelsen. All rights reserved.
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
 package registry
 
 import (

--- a/server/command.go
+++ b/server/command.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013 Erik St. Martin, Brian Ketelsen. All rights reserved.
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
 package server
 
 import (

--- a/server/externalapi.go
+++ b/server/externalapi.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013 Erik St. Martin, Brian Ketelsen. All rights reserved.
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
 package server
 
 import (

--- a/server/server.go
+++ b/server/server.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013 Erik St. Martin, Brian Ketelsen. All rights reserved.
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
 package server
 
 import (

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013 Erik St. Martin, Brian Ketelsen. All rights reserved.
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
 package server
 
 import (


### PR DESCRIPTION
Add a three line header to each .go file explaining the license.
