### PR TITLE
Make SkyDNS a forwarder

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func init() {
 	flag.StringVar(&graphiteServer, "graphiteServer", "", "Graphite Server connection string e.g. 127.0.0.1:2003")
 	flag.StringVar(&stathatUser, "stathatUser", "", "StatHat account for metrics")
 	flag.StringVar(&secret, "secret", "", "Shared secret for use with http api")
-	flag.StringVar(&nameserver, "nameserver", "", "Nameserver address to forward (non-local) queries to")
+	flag.StringVar(&nameserver, "nameserver", "", "Nameserver address to forward (non-local) queries to e.g. 8..8.8.8:53")
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func init() {
 	flag.StringVar(&graphiteServer, "graphiteServer", "", "Graphite Server connection string e.g. 127.0.0.1:2003")
 	flag.StringVar(&stathatUser, "stathatUser", "", "StatHat account for metrics")
 	flag.StringVar(&secret, "secret", "", "Shared secret for use with http api")
-	flag.StringVar(&nameserver, "nameserver", "", "Nameserver address to forward (non-local) queries to e.g. 8..8.8.8:53")
+	flag.StringVar(&nameserver, "nameserver", "", "Nameserver address to forward (non-local) queries to e.g. 8.8.8.8:53")
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var (
 	metricsToStdErr                    bool
 	graphiteServer, stathatUser        string
 	secret                             string
+	nameserver                         string // TODO(miek): make []string
 )
 
 func init() {
@@ -39,6 +40,7 @@ func init() {
 	flag.StringVar(&graphiteServer, "graphiteServer", "", "Graphite Server connection string e.g. 127.0.0.1:2003")
 	flag.StringVar(&stathatUser, "stathatUser", "", "StatHat account for metrics")
 	flag.StringVar(&secret, "secret", "", "Shared secret for use with http api")
+	flag.StringVar(&nameserver, "nameserver, "", "Namserver address to forward (non-local) queries too")
 }
 
 func main() {
@@ -87,11 +89,9 @@ func main() {
 	}
 
 	waiter, err := s.Start()
-
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
-
 	waiter.Wait()
 }

--- a/main.go
+++ b/main.go
@@ -40,13 +40,14 @@ func init() {
 	flag.StringVar(&graphiteServer, "graphiteServer", "", "Graphite Server connection string e.g. 127.0.0.1:2003")
 	flag.StringVar(&stathatUser, "stathatUser", "", "StatHat account for metrics")
 	flag.StringVar(&secret, "secret", "", "Shared secret for use with http api")
-	flag.StringVar(&nameserver, "nameserver", "", "Nameserver address to forward (non-local) queries to e.g. 8.8.8.8:53")
+	flag.StringVar(&nameserver, "nameserver", "", "Nameserver address to forward (non-local) queries to e.g. 8.8.8.8:53,8.8.4.4:53")
 }
 
 func main() {
 	members := make([]string, 0)
 	raft.SetLogLevel(0)
 	flag.Parse()
+	nameservers := strings.Split(nameserver, ",")
 
 	if discover {
 		ns, err := net.LookupNS(domain)
@@ -68,7 +69,7 @@ func main() {
 		members = strings.Split(join, ",")
 	}
 
-	s := server.NewServer(members, domain, ldns, lhttp, dataDir, rtimeout, wtimeout, secret, []string{nameserver})
+	s := server.NewServer(members, domain, ldns, lhttp, dataDir, rtimeout, wtimeout, secret, nameservers)
 
 	// Set up metrics if specified on the command line
 	if metricsToStdErr {

--- a/main.go
+++ b/main.go
@@ -40,14 +40,12 @@ func init() {
 	flag.StringVar(&graphiteServer, "graphiteServer", "", "Graphite Server connection string e.g. 127.0.0.1:2003")
 	flag.StringVar(&stathatUser, "stathatUser", "", "StatHat account for metrics")
 	flag.StringVar(&secret, "secret", "", "Shared secret for use with http api")
-	flag.StringVar(&nameserver, "nameserver, "", "Namserver address to forward (non-local) queries too")
+	flag.StringVar(&nameserver, "nameserver", "", "Nameserver address to forward (non-local) queries to")
 }
 
 func main() {
 	members := make([]string, 0)
-
 	raft.SetLogLevel(0)
-
 	flag.Parse()
 
 	if discover {
@@ -70,7 +68,7 @@ func main() {
 		members = strings.Split(join, ",")
 	}
 
-	s := server.NewServer(members, domain, ldns, lhttp, dataDir, rtimeout, wtimeout, secret)
+	s := server.NewServer(members, domain, ldns, lhttp, dataDir, rtimeout, wtimeout, secret, []string{nameserver})
 
 	// Set up metrics if specified on the command line
 	if metricsToStdErr {

--- a/server/server.go
+++ b/server/server.go
@@ -45,13 +45,6 @@ var (
 	removeServiceCount metrics.Counter
 )
 
-const (
-	rttUNREACHABLE = iota
-	rrtGOOD 
-	rttFAIR
-	rrtBAD
-)
-
 func init() {
 	// Register Raft Commands
 	raft.RegisterCommand(&AddServiceCommand{})
@@ -81,7 +74,6 @@ func init() {
 type Server struct {
 	members      []string // initial members to join with
 	nameservers  []string // nameservers to forward to
-	rtt          []int    // rtt for remote nameservers
 	domain       string
 	dnsAddr      string
 	httpAddr     string

--- a/server/server.go
+++ b/server/server.go
@@ -152,7 +152,7 @@ func (s *Server) HTTPAddr() string { return s.httpAddr }
 // Start starts a DNS server and blocks waiting to be killed.
 func (s *Server) Start() (*sync.WaitGroup, error) {
 	var err error
-	log.Printf("Initializing Server. DNS Addr: %q, HTTP Addr: %q, Data Dir: %q", s.dnsAddr, s.httpAddr, s.dataDir)
+	log.Printf("Initializing Server. DNS Addr: %q, HTTP Addr: %q, Data Dir: %q, Forwarders: %q", s.dnsAddr, s.httpAddr, s.dataDir, s.nameservers)
 
 	// Initialize and start Raft server.
 	transporter := raft.NewHTTPTransporter("/raft")

--- a/server/server.go
+++ b/server/server.go
@@ -36,12 +36,21 @@ import (
    TTL cleanup thread should shutdown/start based on being elected master
 */
 
-var expiredCount metrics.Counter
-var requestCount metrics.Counter
-var addServiceCount metrics.Counter
-var updateTTLCount metrics.Counter
-var getServiceCount metrics.Counter
-var removeServiceCount metrics.Counter
+var (
+	expiredCount       metrics.Counter
+	requestCount       metrics.Counter
+	addServiceCount    metrics.Counter
+	updateTTLCount     metrics.Counter
+	getServiceCount    metrics.Counter
+	removeServiceCount metrics.Counter
+)
+
+const (
+	rttUNREACHABLE = iota
+	rrtGOOD 
+	rttFAIR
+	rrtBAD
+)
 
 func init() {
 	// Register Raft Commands

--- a/server/server.go
+++ b/server/server.go
@@ -412,6 +412,8 @@ func (s *Server) ServeDNSForward(w dns.ResponseWriter, req *dns.Msg) {
 	// TODO(miek): client timeouts, slight larger because we are recursing?
 	c := &dns.Client{Net: network}
 
+	// TODO(miek): add another random value so the client can not influence
+	// which server we choose?
 	// use request Id for "random" nameserver selection
 	nsid := int(req.Id) % len(s.nameservers)
 	try := 0
@@ -449,7 +451,6 @@ func (s *Server) getARecords(q dns.Question) (records []dns.RR, err error) {
 		if err != nil {
 			return
 		}
-
 		records = append(records, &dns.A{Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 15}, A: net.ParseIP(h)})
 	}
 
@@ -460,11 +461,9 @@ func (s *Server) getARecords(q dns.Question) (records []dns.RR, err error) {
 			if err != nil {
 				return
 			}
-
 			records = append(records, &dns.A{Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 15}, A: net.ParseIP(h)})
 		}
 	}
-
 	return
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -409,6 +409,7 @@ func (s *Server) ServeDNSForward(w dns.ResponseWriter, req *dns.Msg) {
 	if _, ok := w.RemoteAddr().(*net.TCPAddr); ok {
 		network = "tcp"
 	}
+	// TODO(miek): client timeouts, slight larger because we are recursing?
 	c := &dns.Client{Net: network}
 
 	// use request Id for "random" nameserver selection
@@ -425,6 +426,7 @@ Redo:
 	// but only if we have not exausted our nameservers
 	if try < len(s.nameservers) {
 		log.Printf("Error: Failure to Forward DNS Request %q", err)
+		try++
 		nsid = (nsid+1)%len(s.nameservers)
 		goto Redo
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -773,13 +773,13 @@ func TestDNSARecords(t *testing.T) {
 }
 
 func TestDNSForward(t *testing.T) {
-	s := newTestServer("", 9610, 9611, "", "8.8.8.8:53")
+	s := newTestServer("", 9620, 9621, "", "8.8.8.8:53")
 	defer s.Stop()
 	
 	c := new(dns.Client)
 	m := new(dns.Msg)
 	m.SetQuestion("www.example.com.", dns.TypeA)
-	resp, _, err := c.Exchange(m, "localhost:9610")
+	resp, _, err := c.Exchange(m, "localhost:9620")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -788,7 +788,7 @@ func TestDNSForward(t *testing.T) {
 	}
 	// TCP
 	c.Net = "tcp"
-	resp, _, err = c.Exchange(m, "localhost:9610")
+	resp, _, err = c.Exchange(m, "localhost:9620")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -26,7 +26,7 @@ import (
 */
 
 func TestAddService(t *testing.T) {
-	s := newTestServer("", 9500, 9501, "")
+	s := newTestServer("", 9500, 9501, "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -56,7 +56,7 @@ func TestAddService(t *testing.T) {
 }
 
 func TestAddServiceDuplicate(t *testing.T) {
-	s := newTestServer("", 9510, 9511, "")
+	s := newTestServer("", 9510, 9511, "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -94,7 +94,7 @@ func TestAddServiceDuplicate(t *testing.T) {
 }
 
 func TestRemoveService(t *testing.T) {
-	s := newTestServer("", 9520, 9521, "")
+	s := newTestServer("", 9520, 9521, "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -121,7 +121,7 @@ func TestRemoveService(t *testing.T) {
 }
 
 func TestRemoveUnknownService(t *testing.T) {
-	s := newTestServer("", 9530, 9531, "")
+	s := newTestServer("", 9530, 9531, "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -148,7 +148,7 @@ func TestRemoveUnknownService(t *testing.T) {
 }
 
 func TestUpdateTTL(t *testing.T) {
-	s := newTestServer("", 9540, 9541, "")
+	s := newTestServer("", 9540, 9541, "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -186,7 +186,7 @@ func TestUpdateTTL(t *testing.T) {
 }
 
 func TestUpdateTTLUnknownService(t *testing.T) {
-	s := newTestServer("", 9560, 9561, "")
+	s := newTestServer("", 9560, 9561, "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -217,7 +217,7 @@ func TestUpdateTTLUnknownService(t *testing.T) {
 }
 
 func TestGetService(t *testing.T) {
-	s := newTestServer("", 9570, 9571, "")
+	s := newTestServer("", 9570, 9571, "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -259,7 +259,7 @@ func TestGetService(t *testing.T) {
 }
 
 func TestGetEnvironments(t *testing.T) {
-	s := newTestServer("", 8500, 8501, "")
+	s := newTestServer("", 8500, 8501, "", "")
 	defer s.Stop()
 
 	for _, m := range services {
@@ -286,7 +286,7 @@ func TestGetEnvironments(t *testing.T) {
 }
 
 func TestGetRegions(t *testing.T) {
-	s := newTestServer("", 8600, 8601, "")
+	s := newTestServer("", 8600, 8601, "", "")
 	defer s.Stop()
 
 	for _, m := range services {
@@ -313,7 +313,7 @@ func TestGetRegions(t *testing.T) {
 }
 
 func TestAuthenticationFailure(t *testing.T) {
-	s := newTestServer("", 9610, 9611, "supersecretpassword")
+	s := newTestServer("", 9610, 9611, "supersecretpassword", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -343,7 +343,7 @@ func TestAuthenticationFailure(t *testing.T) {
 
 func TestAuthenticationSuccess(t *testing.T) {
 	secret := "myimportantsecret"
-	s := newTestServer("", 9620, 9621, secret)
+	s := newTestServer("", 9620, 9621, secret, "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -373,7 +373,7 @@ func TestAuthenticationSuccess(t *testing.T) {
 }
 
 func TestHostFailure(t *testing.T) {
-	s := newTestServer("", 9630, 9631, "")
+	s := newTestServer("", 9630, 9631, "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -399,7 +399,7 @@ func TestHostFailure(t *testing.T) {
 }
 
 func TestCallback(t *testing.T) {
-	s := newTestServer("", 9640, 9641, "")
+	s := newTestServer("", 9640, 9641, "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -449,7 +449,7 @@ func TestCallback(t *testing.T) {
 }
 
 func TestCallbackFailure(t *testing.T) {
-	s := newTestServer("", 9650, 9651, "")
+	s := newTestServer("", 9650, 9651, "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -672,7 +672,7 @@ var serviceTestArray []servicesTest = []servicesTest{
 }
 
 func TestGetServicesWithQueries(t *testing.T) {
-	s := newTestServer("", 9590, 9591, "")
+	s := newTestServer("", 9590, 9591, "", "")
 	defer s.Stop()
 
 	for _, m := range services {
@@ -700,15 +700,13 @@ func TestGetServicesWithQueries(t *testing.T) {
 }
 
 func TestDNS(t *testing.T) {
-	s := newTestServer("", 9580, 9581, "")
+	s := newTestServer("", 9580, 9581, "", "")
 	defer s.Stop()
 
 	for _, m := range services {
 		s.registry.Add(m)
 	}
-
 	c := new(dns.Client)
-
 	for _, tc := range dnsTestCases {
 		m := new(dns.Msg)
 		m.SetQuestion(tc.Question, dns.TypeSRV)
@@ -759,25 +757,48 @@ func TestDNS(t *testing.T) {
 }
 
 func TestDNSARecords(t *testing.T) {
-	s := newTestServer("", 9600, 9601, "")
+	s := newTestServer("", 9600, 9601, "", "")
 	defer s.Stop()
 
 	c := new(dns.Client)
-
 	m := new(dns.Msg)
 	m.SetQuestion("skydns.local.", dns.TypeA)
 	resp, _, err := c.Exchange(m, "localhost:9600")
-
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if len(resp.Answer) != 1 {
 		t.Fatal("Answer expected to have 2 A records but has", len(resp.Answer))
 	}
 }
 
-func newTestServer(leader string, dnsPort int, httpPort int, secret string) *Server {
+func TestDNSForward(t *testing.T) {
+	s := newTestServer("", 9610, 9611, "", "8.8.8.8:53")
+	defer s.Stop()
+	
+	c := new(dns.Client)
+	m := new(dns.Msg)
+	m.SetQuestion("www.example.com.", dns.TypeA)
+	resp, _, err := c.Exchange(m, "localhost:9610")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Answer) == 0 || resp.Rcode != dns.RcodeSuccess {
+		t.Fatal("Answer expected to have A records or rcode not equal to RcodeSuccess")
+	}
+	// TCP
+	c.Net = "tcp"
+	resp, _, err = c.Exchange(m, "localhost:9610")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Answer) == 0 || resp.Rcode != dns.RcodeSuccess {
+		t.Fatal("Answer expected to have A records or rcode not equal to RcodeSuccess")
+	}
+	// TODO(miek): DNSSEC DO query
+}
+
+func newTestServer(leader string, dnsPort int, httpPort int, secret, nameserver string) *Server {
 	members := make([]string, 0)
 
 	p, _ := ioutil.TempDir("", "skydns-test-")
@@ -789,7 +810,7 @@ func newTestServer(leader string, dnsPort int, httpPort int, secret string) *Ser
 		members = append(members, leader)
 	}
 
-	server := NewServer(members, "skydns.local", net.JoinHostPort("127.0.0.1", strconv.Itoa(dnsPort)), net.JoinHostPort("127.0.0.1", strconv.Itoa(httpPort)), p, 1*time.Second, 1*time.Second, secret)
+	server := NewServer(members, "skydns.local", net.JoinHostPort("127.0.0.1", strconv.Itoa(dnsPort)), net.JoinHostPort("127.0.0.1", strconv.Itoa(httpPort)), p, 1*time.Second, 1*time.Second, secret, []string{nameserver})
 	server.Start()
 
 	return server

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -19,6 +19,12 @@ import (
 	"time"
 )
 
+// keep global port counter that increments with 10 for each
+// new call to newTestServer. The dns server is started on port 'port'
+// the http server is started on 'port+1'.
+var Port = 9490
+var StrPort = "9490" // string equivalent of Port
+
 /* TODO: Tests
    Test Cluster
    Test TTL expiration
@@ -26,7 +32,7 @@ import (
 */
 
 func TestAddService(t *testing.T) {
-	s := newTestServer("", 9500, 9501, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -40,7 +46,6 @@ func TestAddService(t *testing.T) {
 	}
 
 	b, err := json.Marshal(m)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +61,7 @@ func TestAddService(t *testing.T) {
 }
 
 func TestAddServiceDuplicate(t *testing.T) {
-	s := newTestServer("", 9510, 9511, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -94,7 +99,7 @@ func TestAddServiceDuplicate(t *testing.T) {
 }
 
 func TestRemoveService(t *testing.T) {
-	s := newTestServer("", 9520, 9521, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -121,7 +126,7 @@ func TestRemoveService(t *testing.T) {
 }
 
 func TestRemoveUnknownService(t *testing.T) {
-	s := newTestServer("", 9530, 9531, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -134,21 +139,19 @@ func TestRemoveUnknownService(t *testing.T) {
 		Port:        9000,
 		TTL:         4,
 	}
-
 	s.registry.Add(m)
 
 	req, _ := http.NewRequest("DELETE", "/skydns/services/54321", nil)
 	resp := httptest.NewRecorder()
 
 	s.router.ServeHTTP(resp, req)
-
 	if resp.Code != http.StatusNotFound || s.registry.Len() != 1 {
 		t.Fatal("API should return 404 when removing unknown service")
 	}
 }
 
 func TestUpdateTTL(t *testing.T) {
-	s := newTestServer("", 9540, 9541, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -186,7 +189,7 @@ func TestUpdateTTL(t *testing.T) {
 }
 
 func TestUpdateTTLUnknownService(t *testing.T) {
-	s := newTestServer("", 9560, 9561, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -217,7 +220,7 @@ func TestUpdateTTLUnknownService(t *testing.T) {
 }
 
 func TestGetService(t *testing.T) {
-	s := newTestServer("", 9570, 9571, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -259,7 +262,7 @@ func TestGetService(t *testing.T) {
 }
 
 func TestGetEnvironments(t *testing.T) {
-	s := newTestServer("", 8500, 8501, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	for _, m := range services {
@@ -282,11 +285,10 @@ func TestGetEnvironments(t *testing.T) {
 	if !bytes.Equal(resp.Body.Bytes(), []byte(expected)) {
 		t.Fatal("Expected ", expected, " got %s", string(resp.Body.Bytes()))
 	}
-
 }
 
 func TestGetRegions(t *testing.T) {
-	s := newTestServer("", 8600, 8601, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	for _, m := range services {
@@ -309,11 +311,10 @@ func TestGetRegions(t *testing.T) {
 	if !bytes.Equal(resp.Body.Bytes(), []byte(expected)) {
 		t.Fatal("Expected ", expected, " got %s", string(resp.Body.Bytes()))
 	}
-
 }
 
 func TestAuthenticationFailure(t *testing.T) {
-	s := newTestServer("", 9610, 9611, "supersecretpassword", "")
+	s := newTestServer("", "supersecretpassword", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -343,7 +344,7 @@ func TestAuthenticationFailure(t *testing.T) {
 
 func TestAuthenticationSuccess(t *testing.T) {
 	secret := "myimportantsecret"
-	s := newTestServer("", 9620, 9621, secret, "")
+	s := newTestServer("", secret, "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -373,7 +374,7 @@ func TestAuthenticationSuccess(t *testing.T) {
 }
 
 func TestHostFailure(t *testing.T) {
-	s := newTestServer("", 9630, 9631, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -399,7 +400,7 @@ func TestHostFailure(t *testing.T) {
 }
 
 func TestCallback(t *testing.T) {
-	s := newTestServer("", 9640, 9641, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -449,7 +450,7 @@ func TestCallback(t *testing.T) {
 }
 
 func TestCallbackFailure(t *testing.T) {
-	s := newTestServer("", 9650, 9651, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	m := msg.Service{
@@ -672,7 +673,7 @@ var serviceTestArray []servicesTest = []servicesTest{
 }
 
 func TestGetServicesWithQueries(t *testing.T) {
-	s := newTestServer("", 9590, 9591, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	for _, m := range services {
@@ -700,7 +701,7 @@ func TestGetServicesWithQueries(t *testing.T) {
 }
 
 func TestDNS(t *testing.T) {
-	s := newTestServer("", 9580, 9581, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	for _, m := range services {
@@ -710,7 +711,7 @@ func TestDNS(t *testing.T) {
 	for _, tc := range dnsTestCases {
 		m := new(dns.Msg)
 		m.SetQuestion(tc.Question, dns.TypeSRV)
-		resp, _, err := c.Exchange(m, "localhost:9580")
+		resp, _, err := c.Exchange(m, "localhost:" + StrPort)
 
 		if err != nil {
 			t.Fatal(err)
@@ -757,13 +758,13 @@ func TestDNS(t *testing.T) {
 }
 
 func TestDNSARecords(t *testing.T) {
-	s := newTestServer("", 9600, 9601, "", "")
+	s := newTestServer("", "", "")
 	defer s.Stop()
 
 	c := new(dns.Client)
 	m := new(dns.Msg)
 	m.SetQuestion("skydns.local.", dns.TypeA)
-	resp, _, err := c.Exchange(m, "localhost:9600")
+	resp, _, err := c.Exchange(m, "localhost:" + StrPort)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -773,13 +774,13 @@ func TestDNSARecords(t *testing.T) {
 }
 
 func TestDNSForward(t *testing.T) {
-	s := newTestServer("", 9620, 9621, "", "8.8.8.8:53")
+	s := newTestServer("", "", "8.8.8.8:53")
 	defer s.Stop()
 	
 	c := new(dns.Client)
 	m := new(dns.Msg)
 	m.SetQuestion("www.example.com.", dns.TypeA)
-	resp, _, err := c.Exchange(m, "localhost:9620")
+	resp, _, err := c.Exchange(m, "localhost:" + StrPort)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -788,7 +789,7 @@ func TestDNSForward(t *testing.T) {
 	}
 	// TCP
 	c.Net = "tcp"
-	resp, _, err = c.Exchange(m, "localhost:9620")
+	resp, _, err = c.Exchange(m, "localhost:" + StrPort)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -798,20 +799,20 @@ func TestDNSForward(t *testing.T) {
 	// TODO(miek): DNSSEC DO query
 }
 
-func newTestServer(leader string, dnsPort int, httpPort int, secret, nameserver string) *Server {
+func newTestServer(leader string, secret, nameserver string) *Server {
 	members := make([]string, 0)
 
 	p, _ := ioutil.TempDir("", "skydns-test-")
 	if err := os.MkdirAll(p, 0644); err != nil {
 		panic(err.Error())
 	}
-
 	if leader != "" {
 		members = append(members, leader)
 	}
 
-	server := NewServer(members, "skydns.local", net.JoinHostPort("127.0.0.1", strconv.Itoa(dnsPort)), net.JoinHostPort("127.0.0.1", strconv.Itoa(httpPort)), p, 1*time.Second, 1*time.Second, secret, []string{nameserver})
+	Port += 10
+	StrPort = strconv.Itoa(Port)
+	server := NewServer(members, "skydns.local", net.JoinHostPort("127.0.0.1", StrPort), net.JoinHostPort("127.0.0.1", strconv.Itoa(Port+1)), p, 1*time.Second, 1*time.Second, secret, []string{nameserver})
 	server.Start()
-
 	return server
 }


### PR DESCRIPTION
All non-local queries are forwarded to another nameserver (or more) and then returned to the client. This allows SkyDNS to be used in /etc/resolv.conf and also serve as a discovery service.
Note: this does not make SkyDNS a full blown nameserver, it _just_ forwards packets: it is a DNS proxy and it also does not cache.
