### PR TITLE
Use the much short SKYDNS as env variable

### DIFF
--- a/skydnsctl/README.md
+++ b/skydnsctl/README.md
@@ -10,10 +10,10 @@
 
 ### Connect to your skynds http endpoint
 To connect to the skydns http endpoint for issuing commands set the environment 
-variable `SKYDNS_HTTP_ADDR` or you can run the cli app with the `--host` flag.
+variable `SKYDNS` or you can run the cli app with the `--host` flag.
 
 ```bash
-expose SKYDNS_HTTP_ADDR="http://localhost:8080"
+expose SKYDNS="http://localhost:8080"
 # OR
 skydnsctl --host "http://localhost:8080" 1001
 ```

--- a/skydnsctl/main.go
+++ b/skydnsctl/main.go
@@ -50,7 +50,7 @@ func loadCommands(app *cli.App) {
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{"json", "output to json"},
-		cli.StringFlag{"host", os.Getenv("SKYDNS_HTTP_ADDR"), "url to skydns's http endpoints ( defaults to environment var SKYDNS_HTTP_ADDR )"},
+		cli.StringFlag{"host", os.Getenv("SKYDNS"), "url to SkyDNS's http endpoints (defaults to environment var SKYDNS)"},
 		cli.StringFlag{"secret", "", "secret to authenticate with"},
 	}
 


### PR DESCRIPTION
I know I'm updating a PR from Michael, but I think this is much. In upcoming PR's i'll add SKYDNS_DNS for the DNS port and add stuff the skydnsctl to perform DNS queries.
