### PR TITLE
Dnsclient infrastructure

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -23,7 +23,7 @@ type (
 		base   string
 		dnsport int
 		secret string
-		c      *http.Client
+		h      *http.Client
 		d      *dns.Client
 	}
 
@@ -43,7 +43,7 @@ func NewClient(base, secret string, dnsport int) (*Client, error) {
 		base:   base,
 		dnsport: dnsport,
 		secret: secret,
-		c:      &http.Client{},
+		h:      &http.Client{},
 		d:      &dns.Client{},
 	}, nil
 }
@@ -57,7 +57,7 @@ func (c *Client) Add(uuid string, s *msg.Service) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.c.Do(req)
+	resp, err := c.h.Do(req)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (c *Client) Delete(uuid string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.c.Do(req)
+	resp, err := c.h.Do(req)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (c *Client) Get(uuid string) (*msg.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.c.Do(req)
+	resp, err := c.h.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (c *Client) Update(uuid string, ttl uint32) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.c.Do(req)
+	resp, err := c.h.Do(req)
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func (c *Client) GetAllServices() ([]*msg.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.c.Do(req)
+	resp, err := c.h.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (c *Client) GetRegions() (NameCount, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.c.Do(req)
+	resp, err := c.h.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (c *Client) GetEnvironments() (NameCount, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.c.Do(req)
+	resp, err := c.h.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (c *Client) AddCallback(uuid string, cb *msg.Callback) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.c.Do(req)
+	resp, err := c.h.Do(req)
 	if err != nil {
 		return err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -192,7 +192,7 @@ func (c *Client) GetRegionsDNS() (NameCount, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	// TODO(miek): soon! reuse name count for DNS replies too
 	var out NameCount
 	resp = resp
 	return out, nil

--- a/client/client.go
+++ b/client/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/miekg/dns"
 	"github.com/skynetservices/skydns/msg"
 	"io"
 	"net/http"
@@ -20,23 +21,30 @@ var (
 type (
 	Client struct {
 		base   string
+		dnsport int
 		secret string
 		c      *http.Client
+		d      *dns.Client
 	}
 
 	NameCount map[string]int
 )
 
 // NewClient creates a new skydns client with the specificed host address
-func NewClient(base, secret string) (*Client, error) {
+func NewClient(base, secret string, dnsport int) (*Client, error) {
 	if base == "" {
 		return nil, ErrNoHttpAddress
+	}
+	if dnsport == 0 {
+		dnsport = 53
 	}
 
 	return &Client{
 		base:   base,
+		dnsport: dnsport,
 		secret: secret,
 		c:      &http.Client{},
+		d:      &dns.Client{},
 	}, nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -168,7 +168,6 @@ func (c *Client) GetAllServicesDNS() ([]*msg.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO(miek): v4 and v6, do in parallel see who's first?
 	resp, _, err := c.d.Exchange(req, c.basedns)
 	if err != nil {
 		return nil, err
@@ -178,7 +177,7 @@ func (c *Client) GetAllServicesDNS() ([]*msg.Service, error) {
 	for i, r := range resp.Answer {
 		if v, ok := r.(*dns.SRV); ok {
 			s[i] = &msg.Service{
-				// TODO(miek): uehh, stuff it in Name
+				// TODO(miek): uehh, stuff it in Name?
 				Name: v.Header().Name + " (Priority: " + strconv.Itoa(int(v.Priority)) + ", " + "Weight: " + strconv.Itoa(int(v.Weight)) +")",
 				Host: v.Target,
 				Port: v.Port,

--- a/client/client.go
+++ b/client/client.go
@@ -28,13 +28,14 @@ type (
 		basedns string
 		domain  string
 		d       *dns.Client
+		DNS	bool // if true use the DNS when listing servies
 	}
 
 	NameCount map[string]int
 )
 
 // NewClient creates a new skydns client with the specificed host address and
-// dns port.
+// DNS port.
 func NewClient(base, secret, dnsdomain string, dnsport int) (*Client, error) {
 	if base == "" {
 		return nil, ErrNoHttpAddress

--- a/server/server.go
+++ b/server/server.go
@@ -422,7 +422,7 @@ func (s *Server) ServeDNSForward(w dns.ResponseWriter, req *dns.Msg) {
 Redo:
 	r, _, err := c.Exchange(req, s.nameservers[nsid])
 	if err == nil {
-		//log.Printf("Forwarded DNS Request %q to %q", req.Question[0].Name, s.nameservers[nsid])
+		log.Printf("Forwarded DNS Request %q to %q", req.Question[0].Name, s.nameservers[nsid])
 		w.WriteMsg(r)
 		return
 	}

--- a/skydnsctl/README.md
+++ b/skydnsctl/README.md
@@ -14,7 +14,7 @@ variable `SKYDNS` or you can run the cli app with the `--host` flag.
 ```bash
 export SKYDNS="http://localhost:8080"
 # OR
-skydnsctl --host "http://localhost:8080" 1001
+skydnsctl --host "http://localhost:8080"
 ```
 
 ### SkyDNS DNS endpoint

--- a/skydnsctl/README.md
+++ b/skydnsctl/README.md
@@ -1,22 +1,26 @@
-## skydnsctl - cli tool for interacting with skynds
+## skydnsctl - cli tool for interacting with SkyDNS
 
-
-#### Commands:
+#### Commands
 * add
 * get
 * update
 * delete
 
 
-### Connect to your skynds http endpoint
+### Connect to your SkydNS HTTP endpoint
 To connect to the skydns http endpoint for issuing commands set the environment 
 variable `SKYDNS` or you can run the cli app with the `--host` flag.
 
 ```bash
-expose SKYDNS="http://localhost:8080"
+export SKYDNS="http://localhost:8080"
 # OR
 skydnsctl --host "http://localhost:8080" 1001
 ```
+
+### SkyDNS DNS endpoint
+
+For the DNS discovery port 53 is assumed on the 
+
 
 #### Add a new service
 

--- a/skydnsctl/README.md
+++ b/skydnsctl/README.md
@@ -8,7 +8,7 @@
 
 
 ### Connect to your SkydNS HTTP endpoint
-To connect to the skydns http endpoint for issuing commands set the environment 
+To connect to the SkyDNS HTTP endpoint for issuing commands set the environment 
 variable `SKYDNS` or you can run the cli app with the `--host` flag.
 
 ```bash
@@ -19,8 +19,12 @@ skydnsctl --host "http://localhost:8080" 1001
 
 ### SkyDNS DNS endpoint
 
-For the DNS discovery port 53 is assumed on the 
+For the DNS discovery port 53 is assumed on the URL mentioned in `--host` or in 
+the SKYDNS environment variable. This can overrulled with `--dnsport` or the environment
+variable SKYDNS_DNSPORT.
 
+The default domain used for DNS queries is `skydns.local`, but this can be overruled with the
+environment variable SKYDNS_DNSDOMAIN or the option `--dnsdomain`.
 
 #### Add a new service
 
@@ -30,7 +34,7 @@ skydnsctl add  1001 '{"Name":"TestService","Version":"1.0.0","Environment":"Prod
 1001 added to skydns
 ```
 
-#### Get an existing service by uuid
+#### Get an existing service by UUID
 
 ```bash
 skydnsctl 1001

--- a/skydnsctl/main.go
+++ b/skydnsctl/main.go
@@ -186,7 +186,13 @@ func getAction(c *cli.Context) {
 
 		writeService(c, service)
 	} else { // or get all services
-		services, err := skydns.GetAllServices()
+		var services []*msg.Service
+		var err error
+		if skydns.DNS {
+			services, err = skydns.GetAllServicesDNS()
+		} else {
+			services, err = skydns.GetAllServices()
+		}
 		if err != nil {
 			writeError(err)
 		}

--- a/skydnsctl/main.go
+++ b/skydnsctl/main.go
@@ -43,7 +43,11 @@ func newClientFromContext(c *cli.Context) (*client.Client, error) {
 		dnsdomain = c.GlobalString("dnsdomain")
 		secret    = c.GlobalString("secret")
 	)
-	return client.NewClient(base, secret, dnsdomain, dnsport)
+	s, e := client.NewClient(base, secret, dnsdomain, dnsport)
+	if e == nil {
+		s.DNS = c.Bool("d") // currently only defined when listing services
+	}
+	return s, e
 }
 
 func loadCommands(app *cli.App) {
@@ -53,7 +57,7 @@ func loadCommands(app *cli.App) {
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{"json", "output to json"},
 		cli.StringFlag{"host", os.Getenv("SKYDNS"), "url to SkyDNS's HTTP endpoints (defaults to env. var. SKYDNS)"},
-		cli.StringFlag{"dnsport", 
+		cli.StringFlag{"dnsport",
 			func() string {
 				x := os.Getenv("SKYDNS_DNSPORT")
 				if x == "" {
@@ -77,7 +81,7 @@ func loadCommands(app *cli.App) {
 			Name:   "list",
 			Usage:  "list a service from skydns",
 			Action: getAction,
-			Flags: []cli.Flag{cli.BoolFlag{"d", "use DNS instead of HTTP"}},
+			Flags:  []cli.Flag{cli.BoolFlag{"d", "use DNS instead of HTTP"}},
 		},
 		{
 			Name:   "add",

--- a/skydnsctl/main.go
+++ b/skydnsctl/main.go
@@ -74,6 +74,11 @@ func loadCommands(app *cli.App) {
 
 	app.Commands = []cli.Command{
 		{
+			Name:   "get",
+			Usage:  "list a new service from skydns",
+			Action: getAction,
+		},
+		{
 			Name:   "add",
 			Usage:  "add a new service to skydns",
 			Action: addAction,

--- a/skydnsctl/main.go
+++ b/skydnsctl/main.go
@@ -74,7 +74,7 @@ func loadCommands(app *cli.App) {
 
 	app.Commands = []cli.Command{
 		{
-			Name:   "get",
+			Name:   "list",
 			Usage:  "list a new service from skydns",
 			Action: getAction,
 		},

--- a/skydnsctl/main.go
+++ b/skydnsctl/main.go
@@ -75,7 +75,7 @@ func loadCommands(app *cli.App) {
 	app.Commands = []cli.Command{
 		{
 			Name:   "list",
-			Usage:  "list a new service from skydns",
+			Usage:  "list a service from skydns",
 			Action: getAction,
 		},
 		{

--- a/skydnsctl/main.go
+++ b/skydnsctl/main.go
@@ -38,10 +38,12 @@ func writeService(c *cli.Context, service *msg.Service) {
 
 func newClientFromContext(c *cli.Context) (*client.Client, error) {
 	var (
-		base   = c.GlobalString("host")
-		secret = c.GlobalString("secret")
+		base      = c.GlobalString("host")
+		dnsport   = c.GlobalInt("dnsport")
+		dnsdomain = c.GlobalString("dnsdomain")
+		secret    = c.GlobalString("secret")
 	)
-	return client.NewClient(base, secret)
+	return client.NewClient(base, secret, dnsdomain, dnsport)
 }
 
 func loadCommands(app *cli.App) {
@@ -50,7 +52,23 @@ func loadCommands(app *cli.App) {
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{"json", "output to json"},
-		cli.StringFlag{"host", os.Getenv("SKYDNS"), "url to SkyDNS's http endpoints (defaults to environment var SKYDNS)"},
+		cli.StringFlag{"host", os.Getenv("SKYDNS"), "url to SkyDNS's HTTP endpoints (defaults to env. var. SKYDNS)"},
+		cli.StringFlag{"dnsport", 
+			func() string {
+				x := os.Getenv("SKYDNS_DNSPORT")
+				if x == "" {
+					x = "53"
+				}
+				return x
+			}(), "DNS port of SkyDNS's DNS endpoint (defaults to env. var. SKYDNS_DNSPORT or 53)"},
+		cli.StringFlag{"dnsdomain",
+			func() string {
+				x := os.Getenv("SKYDNS_DNSDOMAIN")
+				if x == "" {
+					x = "skydns.local"
+				}
+				return x
+			}(), "DNS domain of SkyDNS (defaults to env. var. SKYDNS_DNSDOMAIN or skydns.local)"},
 		cli.StringFlag{"secret", "", "secret to authenticate with"},
 	}
 

--- a/skydnsctl/main.go
+++ b/skydnsctl/main.go
@@ -47,7 +47,7 @@ func newClientFromContext(c *cli.Context) (*client.Client, error) {
 }
 
 func loadCommands(app *cli.App) {
-	// default to getting a service
+	// default to listing a service
 	app.Action = getAction
 
 	app.Flags = []cli.Flag{
@@ -77,6 +77,7 @@ func loadCommands(app *cli.App) {
 			Name:   "list",
 			Usage:  "list a service from skydns",
 			Action: getAction,
+			Flags: []cli.Flag{cli.BoolFlag{"d", "use DNS instead of HTTP"}},
 		},
 		{
 			Name:   "add",


### PR DESCRIPTION
This adds the infrastructure for querying SkyDNS via the DNS. The actual querying is not implemented (yet!). 
Also lots of documentation (typos and other stuff) fixes all over the map. Fixes in the client to actual list all the actions it supports. Rename get to list in the client.
