### PR TITLE
Use resolv.conf nameserver, when -nameserver is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Which takes the following flags
 - -graphiteServer - When this flag is set to a Graphite Server URL:PORT, metrics will be posted to a graphite server
 - -stathatUser - When this flag is set to a valid StatHat user, metrics will be posted to that user's StatHat account periodically
 - -secret - When this variable is set, the HTTP api will require an authorization header that matches the secret passed to skydns when it starts  
-- -nameserver - Nameserver address to forward (non-local) queries to e.g. "8.8.8.8:53,8.8.4.4:53", in other words an IP:PORT where multiple nameserver maybe listed, separated by a comma "`,`".
+- -nameserver - Nameserver address to forward (non-local) queries to e.g. "8.8.8.8:53,8.8.4.4:53", in other words an IP:PORT, where multiple nameservers maybe listed separated by a comma "`,`". If this list is empty,
+SkyDNS will parse /etc/resolv.conf and will use the nameservers listed there.
 
 ##API
 ### Service Announcements

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Which takes the following flags
 - -graphiteServer - When this flag is set to a Graphite Server URL:PORT, metrics will be posted to a graphite server
 - -stathatUser - When this flag is set to a valid StatHat user, metrics will be posted to that user's StatHat account periodically
 - -secret - When this variable is set, the HTTP api will require an authorization header that matches the secret passed to skydns when it starts  
-- -nameserver - Nameserver address to forward (non-local) queries to e.g. "8.8.8.8:53,8.8.4.4:53", in other words an IP:PORT, where multiple nameservers maybe listed separated by a comma "`,`". If this list is empty,
+- -nameserver - Nameserver address to forward (non-local) queries to e.g. "8.8.8.8:53,8.8.4.4:53", in other words an IP:PORT, where multiple nameservers maybe listed separated by a comma "`,`". If this list is empty (""),
 SkyDNS will parse /etc/resolv.conf and will use the nameservers listed there.
 
 ##API

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"flag"
 	"github.com/goraft/raft"
+	"github.com/miekg/dns"
 	"github.com/rcrowley/go-metrics"
 	"github.com/rcrowley/go-metrics/stathat"
 	"github.com/skynetservices/skydns/server"
@@ -48,6 +49,18 @@ func main() {
 	raft.SetLogLevel(0)
 	flag.Parse()
 	nameservers := strings.Split(nameserver, ",")
+	if len(nameservers) == 0 {
+		nameservers = make([]string, 0)
+		config, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+		if err != nil {
+			for _, s := range config.Servers {
+				nameservers = append(nameservers, net.JoinHostPort(s, config.Port))
+			}
+		} else {
+			log.Fatal(err)
+			return
+		}
+	}
 
 	if discover {
 		ns, err := net.LookupNS(domain)

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ var (
 	metricsToStdErr                    bool
 	graphiteServer, stathatUser        string
 	secret                             string
-	nameserver                         string // TODO(miek): make []string
+	nameserver                         string
 )
 
 func init() {
@@ -49,10 +49,11 @@ func main() {
 	raft.SetLogLevel(0)
 	flag.Parse()
 	nameservers := strings.Split(nameserver, ",")
-	if len(nameservers) == 0 {
+	// empty argument given
+	if len(nameservers) == 1 && nameservers[0] == "" {
 		nameservers = make([]string, 0)
 		config, err := dns.ClientConfigFromFile("/etc/resolv.conf")
-		if err != nil {
+		if err == nil {
 			for _, s := range config.Servers {
 				nameservers = append(nameservers, net.JoinHostPort(s, config.Port))
 			}


### PR DESCRIPTION
Allow SkyDNS for forward DNS queries using the nameservers in /etc/resolv.conf
