### PR TITLE
Allow skydns itself to use env variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,9 +31,30 @@ var (
 func init() {
 	flag.StringVar(&join, "join", "", "Member of SkyDNS cluster to join can be comma separated list")
 	flag.BoolVar(&discover, "discover", false, "Auto discover SkyDNS cluster. Performs an NS lookup on the -domain to find SkyDNS members")
-	flag.StringVar(&domain, "domain", "skydns.local", "Domain to anchor requests to")
-	flag.StringVar(&ldns, "dns", "127.0.0.1:53", "IP:Port to bind to for DNS")
-	flag.StringVar(&lhttp, "http", "127.0.0.1:8080", "IP:Port to bind to for HTTP")
+	flag.StringVar(&domain, "domain",
+		func() string {
+			if x := os.Getenv("SKYDNS_DOMAIN"); x != "" {
+				return x
+			}
+			return "skydns.local"
+		}(), "Domain to anchor requests to or env. var. SKYDNS_DOMAIN")
+	flag.StringVar(&ldns, "dns",
+		func() string {
+			if x := os.Getenv("SKYDNS_DNS"); x != "" {
+				return x
+			}
+			return "127.0.0.1:53"
+		}(), "IP:Port to bind to for DNS or env. var SKYDNS_DNS")
+	flag.StringVar(&lhttp, "http",
+		func() string {
+			if x := os.Getenv("SKYDNS"); x != "" {
+				// get rid of http or https
+				x1 := strings.TrimPrefix(x, "https://")
+				x1 = strings.TrimPrefix(x1, "http://")
+				return x1
+			}
+			return "127.0.0.1:8080"
+		}(), "IP:Port to bind to for HTTP or env. var. SKYDNS")
 	flag.StringVar(&dataDir, "data", "./data", "SkyDNS data directory")
 	flag.DurationVar(&rtimeout, "rtimeout", 2*time.Second, "Read timeout")
 	flag.DurationVar(&wtimeout, "wtimeout", 2*time.Second, "Write timeout")

--- a/skydnsctl/main.go
+++ b/skydnsctl/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/skynetservices/skydns/msg"
 	"os"
 	"strconv"
+	"strings"
 )
 
 func writeError(err error) {
@@ -60,7 +61,10 @@ func loadCommands(app *cli.App) {
 		cli.StringFlag{"dns",
 			func() string {
 				if x := os.Getenv("SKYDNS_DNS"); x != "" {
-					return x
+					if strings.HasPrefix(x, "http") {
+						return x
+					}
+					return "http://" + x // default to http for now
 				}
 				return "127.0.0.1:53"
 			}(), "DNS port of SkyDNS's DNS endpoint (defaults to env. var. SKYDNS_DNS)"},

--- a/skydnsctl/main.go
+++ b/skydnsctl/main.go
@@ -38,12 +38,12 @@ func writeService(c *cli.Context, service *msg.Service) {
 
 func newClientFromContext(c *cli.Context) (*client.Client, error) {
 	var (
-		base      = c.GlobalString("host")
-		dnsport   = c.GlobalInt("dnsport")
-		dnsdomain = c.GlobalString("dnsdomain")
-		secret    = c.GlobalString("secret")
+		base   = c.GlobalString("host")
+		dns    = c.GlobalString("dns")
+		domain = c.GlobalString("domain")
+		secret = c.GlobalString("secret")
 	)
-	s, e := client.NewClient(base, secret, dnsdomain, dnsport)
+	s, e := client.NewClient(base, secret, domain, dns)
 	if e == nil {
 		s.DNS = c.Bool("d") // currently only defined when listing services
 	}
@@ -57,22 +57,20 @@ func loadCommands(app *cli.App) {
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{"json", "output to json"},
 		cli.StringFlag{"host", os.Getenv("SKYDNS"), "url to SkyDNS's HTTP endpoints (defaults to env. var. SKYDNS)"},
-		cli.StringFlag{"dnsport",
+		cli.StringFlag{"dns",
 			func() string {
-				x := os.Getenv("SKYDNS_DNSPORT")
-				if x == "" {
-					x = "53"
+				if x := os.Getenv("SKYDNS_DNS"); x != "" {
+					return x
 				}
-				return x
-			}(), "DNS port of SkyDNS's DNS endpoint (defaults to env. var. SKYDNS_DNSPORT or 53)"},
-		cli.StringFlag{"dnsdomain",
+				return "127.0.0.1:53"
+			}(), "DNS port of SkyDNS's DNS endpoint (defaults to env. var. SKYDNS_DNS)"},
+		cli.StringFlag{"domain",
 			func() string {
-				x := os.Getenv("SKYDNS_DNSDOMAIN")
-				if x == "" {
-					x = "skydns.local"
+				if x := os.Getenv("SKYDNS_DOMAIN"); x != "" {
+					return x
 				}
-				return x
-			}(), "DNS domain of SkyDNS (defaults to env. var. SKYDNS_DNSDOMAIN or skydns.local)"},
+				return "skydns.local"
+			}(), "DNS domain of SkyDNS (defaults to env. var. SKYDNS_DOMAIN))"},
 		cli.StringFlag{"secret", "", "secret to authenticate with"},
 	}
 


### PR DESCRIPTION
Reuse the variables defined in skydnsctl for skydns itself. Also rename
them slightly to keep the two much more in sync.

SKYDNS_DNSPORT -> SKYDNS_DNS (something like 127.0.0.1:1053) in stead of a number
SKYDNS_DNSDOMAIN -> SKYDNS_DOMAIN (a string like skydns.local)

The environment variable SKYDNS is used in skydns, the prefix http:// is
removed before use. This might confuse people.

Sadly this is a minor backward incompatible change, because
skydns.NewClient needed to be changed
