### PR TITLE
Fix DNS replies

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -372,6 +372,9 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		}
 		m.Answer = append(m.Answer, records...)
 	}
+	if len(m.Answer) == 0 { // Send back a NODATA response
+		m.Ns = s.createSOA()
+	}
 }
 
 // ServeDNSForward forwards a request to a nameservers and returns the response.
@@ -761,18 +764,17 @@ func (s *Server) authHTTPWrapper(handler http.HandlerFunc) http.HandlerFunc {
 	return handler
 }
 
-
 // Return a SOA record for this SkyDNS instance
 func (s *Server) createSOA() []dns.RR {
 	dom := dns.Fqdn(s.domain)
 	soa := &dns.SOA{Hdr: dns.RR_Header{Name: dom, Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 3600},
-		Ns: "skydns." + dom, // what is the primary NS for skydns?
-		Mbox: "hostmaster." + dom,
-		Serial: uint32(time.Now().Unix()),
+		Ns:      "skydns." + dom, // what is the primary NS for skydns?
+		Mbox:    "hostmaster." + dom,
+		Serial:  uint32(time.Now().Unix()),
 		Refresh: 28800,
-		Retry: 7200,
-		Expire: 604800,
-		Minttl: 3600,
+		Retry:   7200,
+		Expire:  604800,
+		Minttl:  3600,
 	}
 	return []dns.RR{soa}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -361,7 +361,7 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		m.Extra = append(m.Extra, extra...)
 	}
 
-	if q.Qtype == dns.TypeANY || q.Qtype == dns.TypeA || q.Qtype == dns.TypeAAAA {
+	if q.Qtype == dns.TypeA || q.Qtype == dns.TypeAAAA {
 		records, err := s.getARecords(q)
 
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -341,6 +341,8 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	}
 	m := new(dns.Msg)
 	m.SetReply(req)
+	m.Authoritative = true
+	m.RecursionAvailable = true
 	m.Answer = make([]dns.RR, 0, 10)
 	defer w.WriteMsg(m)
 
@@ -348,7 +350,8 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		records, extra, err := s.getSRVRecords(q)
 
 		if err != nil {
-			m.SetRcode(req, dns.RcodeServerFailure)
+			// We are authoritative for this name, but it does not exist: NXDOMAIN
+			m.SetRcode(req, dns.RcodeNameError)
 			log.Println("Error: ", err)
 			return
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -384,6 +384,8 @@ func (s *Server) ServeDNSForward(w dns.ResponseWriter, req *dns.Msg) {
 		m := new(dns.Msg)
 		m.SetReply(req)
 		m.SetRcode(req, dns.RcodeServerFailure)
+		m.Authoritative = false // no matter what set to false
+		m.RecursionAvailable = true // and this is still true
 		w.WriteMsg(m)
 		return
 	}


### PR DESCRIPTION
Adhere much more to the DNS protocol, give back NXDOMAIN and NODATA responses instead of the more dangerous SERVFAIL.

Also set the header bits correctly: we do provide recursion and we are authoritative for it (skydns.local.)
