### PR TITLE
 Use master for the master nameserver in the SOA record

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -212,12 +212,10 @@ func (s *Server) Stop() {
 // Leader returns the current leader.
 func (s *Server) Leader() string {
 	l := s.raftServer.Leader()
-
 	if l == "" {
 		// We are a single node cluster, we are the leader
 		return s.raftServer.Name()
 	}
-
 	return l
 }
 
@@ -770,7 +768,7 @@ func (s *Server) authHTTPWrapper(handler http.HandlerFunc) http.HandlerFunc {
 func (s *Server) createSOA() []dns.RR {
 	dom := dns.Fqdn(s.domain)
 	soa := &dns.SOA{Hdr: dns.RR_Header{Name: dom, Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 3600},
-		Ns:      "skydns." + dom, // what is the primary NS for skydns?
+		Ns:      "master." + dom,
 		Mbox:    "hostmaster." + dom,
 		Serial:  uint32(time.Now().Unix()),
 		Refresh: 28800,


### PR DESCRIPTION
Small patch to send the correct SOA master nameserver.
